### PR TITLE
Fix photutils breaking and remove old GMU COS weather station

### DIFF
--- a/omegalambda/main/common/util/filereader_utils.py
+++ b/omegalambda/main/common/util/filereader_utils.py
@@ -73,7 +73,7 @@ def findstars(path: str, saturation: Union[int, float], subframe: Optional[Tuple
     data = (image - median) ** 2
     threshold = photutils.detect_threshold(image, nsigma=5)
     if not subframe:
-        starfound = photutils.find_peaks(data, threshold=threshold, box_size=50, border_width=500,
+        starfound = photutils.find_peaks(data, threshold=threshold, box_size=49, border_width=500,
                                          centroid_func=photutils.centroids.centroid_com)
     else:
         config_dict = config_reader.get_config()
@@ -83,7 +83,7 @@ def findstars(path: str, saturation: Union[int, float], subframe: Optional[Tuple
         data_subframe = data[int(y_cent - r):int(y_cent + r), int(x_cent - r):int(x_cent + r)]
         image = image[int(y_cent - r):int(y_cent + r), int(x_cent - r):int(x_cent + r)]
         threshold = threshold[int(y_cent - r):int(y_cent + r), int(x_cent - r):int(x_cent + r)]
-        starfound = photutils.find_peaks(data_subframe, threshold=threshold, box_size=50, border_width=10,
+        starfound = photutils.find_peaks(data_subframe, threshold=threshold, box_size=49, border_width=10,
                                          centroid_func=photutils.centroids.centroid_com)
 
     n = 0
@@ -152,7 +152,7 @@ def _get_all_fwhm(stars, peaks, data, ri, sky, binsize):
         x_cent = stars[ii][0]
         y_cent = stars[ii][1]
         star = data[int(y_cent - ri):int(y_cent + ri), int(x_cent - ri):int(x_cent + ri)] + sky
-        centroidx, centroidy = photutils.centroids.centroid_com(star, oversampling=1)
+        centroidx, centroidy = photutils.centroids.centroid_com(star)
         stary, starx = np.indices(star.shape)
         r = np.hypot(starx - centroidx, stary - centroidy).astype(np.float64)
 

--- a/omegalambda/main/observing/condition_checker.py
+++ b/omegalambda/main/observing/condition_checker.py
@@ -161,29 +161,30 @@ class Conditions(threading.Thread):
 
         """
         s = requests.Session()
-        backup = False
         humidity = wind = rain = temperature = None
-        try:
-            header = requests.head(self.weather_url).headers
-        except (urllib3.exceptions.MaxRetryError, urllib3.exceptions.HTTPError, urllib3.exceptions.TimeoutError,
-                urllib3.exceptions.InvalidHeader, requests.exceptions.ConnectionError, requests.exceptions.Timeout,
-                requests.exceptions.HTTPError):
-            logging.warning('Failed to read GMU website header')
-            backup = True
-        else:
-            if 'Last-Modified' in header:
-                update_time = time_utils.convert_to_datetime_utc(header['Last-Modified'])
-                diff = datetime.datetime.now(datetime.timezone.utc) - update_time
-                if diff > datetime.timedelta(minutes=30):
-                    # Checking when the web page was last modified (may be outdated)
-                    logging.warning("GMU COS Weather Station Web site has not updated in the last 30 minutes! "
-                                    "Using backup weather.gov and weather.com to find temperature/humidity/wind/rain instead.")
-                    backup = True
-            else:
-                logging.warning("GMU COS Weather Station Web site did not return a last modified timestamp, "
-                                "it may be outdated!")
-                backup = True
-
+            
+        ## GMU COS Weather Station Website is no longer functional. 
+        ## Commenting out this section until new website comes online.
+        # try:
+        #     header = requests.head(self.weather_url).headers
+        # except (urllib3.exceptions.MaxRetryError, urllib3.exceptions.HTTPError, urllib3.exceptions.TimeoutError,
+        #         urllib3.exceptions.InvalidHeader, requests.exceptions.ConnectionError, requests.exceptions.Timeout,
+        #         requests.exceptions.HTTPError):
+        #     logging.warning('Failed to read GMU website header')
+        #     backup = True
+        # else:
+        #     if 'Last-Modified' in header:
+        #         if True:
+        #             # Checking when the web page was last modified (may be outdated)
+        #             logging.warning("GMU COS Weather Station Web site has not updated in the last 30 minutes! "
+        #                             "Using backup weather.com to find humidity/wind/rain instead.")
+        #             backup = True
+        #     else:
+        #         logging.warning("GMU COS Weather Station Web site did not return a last modified timestamp, "
+        #                         "it may be outdated!")
+        #         backup = True
+            
+        backup = True
         target_path = os.path.abspath(os.path.join(self.weather_directory, r'weather.txt'))
         if not backup:
             try:
@@ -253,6 +254,7 @@ class Conditions(threading.Thread):
             # Writes the html code to a text file
             file.write(str(self.weather.content))
 
+        logging.debug(f"Humidity: {humidity}, Wind: {wind}, Temperature: {temperature}")
         return humidity, wind, rain, temperature
 
     def rain_check(self):
@@ -352,6 +354,7 @@ class Conditions(threading.Thread):
             True if cloud cover reaches or exceeds the maximum percenage
             defined in the config file, otherwise False.
 
+        TODO: Use weather.com or another source to get cloud cover and take the max of that and satellite data?
         """
         satellite = self.config_dict.cloud_satellite
         day = int(time_utils.days_of_year())


### PR DESCRIPTION
- `photutils.find_peaks`: `box_size` parameter must be odd? https://photutils.readthedocs.io/en/stable/api/photutils.detection.find_peaks.html

- `photutils.centroids.centroid_com`: `oversampling` parameter deprecated in 1.5.0, removed in 1.6.0. https://photutils.readthedocs.io/en/stable/changelog.html#id8

- Remove nonfunctional GMU COS weather station website from weather checks